### PR TITLE
Add socks5-http-client to package.json in nodes-base

### DIFF
--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -928,6 +928,7 @@
     "showdown": "2.1.0",
     "simple-git": "3.17.0",
     "snowflake-sdk": "1.12.0",
+    "socks5-http-client": "1.0.2",
     "ssh2-sftp-client": "7.2.3",
     "tmp-promise": "3.0.3",
     "ts-ics": "1.2.2",


### PR DESCRIPTION
Add `socks5-http-client` library to the dependencies in `packages/nodes-base/package.json`.

* Add `"socks5-http-client": "1.0.2"` to the `dependencies` section.
* Ensure the `socks5-http-client` entry is alphabetically sorted within the `dependencies` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Wenpiner/n8n/pull/1?shareId=0f422752-ee51-4246-98d8-ce7cef2c5164).